### PR TITLE
Corrected Ctrl+Q shortcut description

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                             <tr>
                                 <td>Anywhere</td>
                                 <td>Ctrl + Q</td>
-                                <td>Close Bookworm</td>
+                                <td>Close Nutty</td>
                             </tr>
                              <tr>
                                 <td>Anywhere</td>


### PR DESCRIPTION
Would be strange if pressing Ctrl+Q in Nutty would close Bookworm!