### PR TITLE
Remove Flatpak from intall options section

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,14 +239,6 @@ sudo apt-get install com.github.babluboy.nutty</pre>
             <p>&nbsp; </p>
             <p>&nbsp; </p>
             <p>
-                <img src="images/flatpak-logo.png" class="img-circle" width="40" height="40">
-                If you have Flatpak on your system, then install Nutty as a Flatpak application by running the following command in terminal</p>
-                 <pre> flatpak install --from https://flathub.org/repo/appstream/com.github.babluboy.nutty.flatpakref</pre>
-                <a href="https://flathub.org/apps/details/com.github.babluboy.nutty"><img src="images/flathub-logo.svg"></a>
-            </p>
-            <p>&nbsp; </p>
-            <p>&nbsp; </p>
-            <p>
                 <img src="images/github-logo.png" class="img-circle" width="35" height="35">
                 If you want to build Nutty from source on GitHub from the latest code base, then ensure the following binaries are installed
                 <li>net-tools</li>


### PR DESCRIPTION
Issue #30 comment 1 and issue #44 comment 1 mentions that [Flatpak support](https://flathub.org/apps/details/com.github.babluboy.nutty) has been removed but the website was not updated with this change and the suggested step isn't working. This PR will remove the Flatpak section until a better solution is viable. 

```bash
$ flatpak install --from https://flathub.org/repo/appstream/com.github.babluboy.nutty.flatpakref
error: Invalid .flatpakref: Key file contains line “<html>” which is not a key-value pair, group, or comment
```