### PR TITLE
Fixed Deprecation warnings by Migrating to GLib library

### DIFF
--- a/src/devices.vala
+++ b/src/devices.vala
@@ -448,16 +448,16 @@ public class NuttyApp.Devices {
 					Constants.COMMAND_FOR_SCHEDULED_DEVICE_SCAN,
 					NuttyApp.Nutty.DEVICE_SCHEDULE_SELECTED.to_string(),
 					NuttyApp.Nutty.nutty_config_path, 
-					NuttyApp.Nutty.app_xdg_path.user_config_folder.get_path() + "/" + Constants.nutty_monitor_scheduler_backup_file_name,
-					NuttyApp.Nutty.app_xdg_path.user_cache_folder.get_path() + "/root_"+ Environment.get_user_name () + "_crontab_temp.txt"
+					GLib.Environment.get_user_config_dir() + "/" + Constants.nutty_monitor_scheduler_backup_file_name,
+					GLib.Environment.get_user_cache_dir() + "/root_" + GLib.Environment.get_user_name() + "_crontab_temp.txt"
 	  	});
 		//execute the command to update user crontab for alerting
 		NuttyApp.Nutty.execute_sync_multiarg_command_pipes({
 					Constants.COMMAND_FOR_SCHEDULED_DEVICE_ALERT,
 					NuttyApp.Nutty.DEVICE_SCHEDULE_SELECTED.to_string(),
 					NuttyApp.Nutty.nutty_config_path, 
-					NuttyApp.Nutty.app_xdg_path.user_config_folder.get_path() + "/" + Constants.nutty_alert_scheduler_backup_file_name,
-					NuttyApp.Nutty.app_xdg_path.user_cache_folder.get_path() + "/user_"+Environment.get_user_name () + "_crontab_temp.txt"
+					GLib.Environment.get_user_config_dir() + "/" + Constants.nutty_monitor_scheduler_backup_file_name,
+					GLib.Environment.get_user_cache_dir() + "/root_" + GLib.Environment.get_user_name() + "_crontab_temp.txt"
   		});
 		info("[END] [FUNCTION:setupDeviceMonitoring]");
 	}

--- a/src/nutty.vala
+++ b/src/nutty.vala
@@ -119,7 +119,7 @@ namespace NuttyApp {
 		public static StringBuilder device_mac_found_in_scan = new StringBuilder("");
 		public static CssProvider cssProvider;
 		public static NuttyApp.Settings settings;
-		public static Granite.Services.Paths app_xdg_path;
+		public static string app_xdg_path;
 
 		construct {
 			build_version = NuttyApp.Constants.nutty_version;
@@ -142,9 +142,8 @@ namespace NuttyApp {
 			Intl.textdomain(GETTEXT_PACKAGE);
 			Intl.bind_textdomain_codeset(GETTEXT_PACKAGE, "utf-8");
 			//Initialize XDG Paths
-			app_xdg_path = new Granite.Services.Paths();
-			app_xdg_path.initialize (Constants.app_id, Constants.NUTTY_SCRIPT_PATH);
-			nutty_config_path = app_xdg_path.user_data_folder.get_path();
+			app_xdg_path = GLib.Environment.get_user_data_dir();
+			nutty_config_path = app_xdg_path + "/" + Constants.app_id + "/" + Constants.NUTTY_SCRIPT_PATH;
 			//migrate user data from .config to .local/share -- to be deleted in the next version
 			if("true" == NuttyApp.Utils.fileOperations(
 							"EXISTS", 


### PR DESCRIPTION
Fixed Deprecation warnings during compilation by migrating from Granite.Services.Paths to GLib.Environment utility library to manage common file paths within the Nutty application.This PR fixes the Issues #96 , #92 and #80 