### PR TITLE
Updated Snapcraft file to build snap for Nutty 2.0

### DIFF
--- a/polkit/com.example.nutty.policy
+++ b/polkit/com.example.nutty.policy
@@ -1,0 +1,20 @@
+<!-- com.example.nutty.policy -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+    "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+
+  <!-- Allow Nutty to run specific commands with sudo -->
+  <action id="com.example.nutty.sudo">
+    <description>Allow Nutty to execute commands with sudo</description>
+    <message>Authentication is required to run commands as superuser</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate>description,"Allow executing commands with sudo for Nutty"</annotate>
+  </action>
+
+</policyconfig>
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,11 +1,14 @@
 name: nutty
-version: 1.0.0
+version: 2.0
 summary: A Network Information Utility
-description: A simple application to provide essential information on network related aspects. Nutty provides basic network information, internet usage and speed and monitors devices connected to the network.
+description: >
+  A simple application to provide essential information on network-related aspects.
+  Nutty provides basic network information, internet usage and speed, and monitors devices connected to the network.
 
 icon: data/icons/24/com.github.babluboy.nutty.svg
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+grade: devel  # Must be 'stable' to release into candidate/stable channels
+confinement: devmode  # Use 'strict' once you have the right plugs and slots
+base: core22  # Specify the base Snap
 
 slots:
   dbus-nutty:
@@ -19,40 +22,66 @@ apps:
     plugs: [home, x11, unity7, network]
 
 parts:
-    nutty:
-        source: https://github.com/babluboy/nutty.git
-        plugin: cmake        
-        configflags: [-DCMAKE_INSTALL_PREFIX=/usr]
-        build-packages:
-            - build-essential
-            - valac
-            - intltool
-            - libnotify-dev
-            - libgee-0.8-dev
-            - debhelper
-            - libgtk-3-dev
-            - granite-demo
-            - libgranite-dev
-            - libsqlite3-dev
-            - libxml2
-            - libxml2-dev
-        stage-packages:
-            - gnome-keyring
-            - gobject-introspection
-            - libgdk-pixbuf2.0-0
-            - libgee-0.8-2
-            - libgtk-3-0
-            - libnotify4
-            - libpango-1.0-0
-            - libpangocairo-1.0-0
-            - net-tools
-            - nmap
-            - traceroute
-            - vnstat
-            - nethogs
-            - gksu
-            - curl
-            - wireless-tools
-            - iproute2
-            - pciutils
-        after: [desktop-gtk3]
+  nutty:
+    source: https://github.com/babluboy/nutty.git
+    plugin: meson  # Use meson plugin for projects using Meson build system
+    meson-parameters: [--prefix=/usr]
+    build-packages:
+      - build-essential
+      - meson  # Install Meson build system
+      - valac
+      - intltool
+      - libnotify-dev
+      - libgee-0.8-dev
+      - debhelper
+      - libgtk-3-dev
+      - granite-demo
+      - libgranite-dev
+      - libsqlite3-dev
+      - libxml2-dev
+      - libxml2
+      
+    stage-packages:
+      - gnome-keyring
+      - gobject-introspection
+      - libgdk-pixbuf2.0-0
+      - libgee-0.8-2
+      - libgtk-3-0
+      - libnotify4
+      - libpango-1.0-0
+      - libpangocairo-1.0-0
+      - net-tools
+      - nmap
+      - traceroute
+      - vnstat
+      - nethogs
+      - curl
+      - wireless-tools
+      - iproute2
+      - pciutils
+      - libgranite6  # Add the missing libgranite6 library
+      - libatm1  # Added another library which is required during snap build process
+
+    after: [desktop-gtk3]
+
+  desktop-gtk3:
+    # Environment for running GTK3 desktop applications
+    plugin: nil
+    build-environment:
+      - DESKTOP_SESSION: ubuntu
+      - DISPLAY: ":0"
+
+    stage-packages:
+      - libgtk-3-0
+      - libgtk-3-bin
+      - adwaita-icon-theme
+
+    override-build: |
+      snapcraftctl build
+
+  polkit:
+    plugin: dump
+    source: ./polkit
+    organize:
+      com.example.nutty.policy: /usr/share/polkit-1/actions/com.example.nutty.policy
+


### PR DESCRIPTION
The changes include 1)Including base snap(core22) in snapcraft.yaml file 2)Added libgranite6 and libatm1 libraries as they are build dependencies(libatm1 is inferred from the error log) 3)Updated the build-system of nutty from cmake to meson and 4)Since gksu which is used to run GUI applications with elevated previlages is deprecated in Ubuntu 18.04 in favour of pkexec for better security,added polkit in snapcraft.yaml file and its policy rules in a seperate polkit directory for the snap package