### PR TITLE
Updated Flatpak Manifest

### DIFF
--- a/FLATPAK BUILD.md
+++ b/FLATPAK BUILD.md
@@ -1,7 +1,8 @@
-## Flatpak Build Instructions from Source - A Walkthrough
+## Flatpak Build Instructions - A Walkthrough
+
 This guide will be helpful if you are a Dev and wan't to contribute to the Nutty's Flatpak as the Dependencies and Runtimes get updated (or) if you are a linux power user who wants to build everything from source:)
 
-First install `flatpak` and `flatpak-builder` in your system using your respective package manager.I am using `apt` here since I run linux distro which is based on debian family.
+First install `flatpak` and `flatpak-builder` in your system using your respective package manager.I am using `apt` here since I run a debian based linux distro.
 ```bash
 sudo apt install flatpak flatpak-builder
 ```
@@ -42,7 +43,8 @@ flatpak-builder --user --install --force-clean build-dir com.github.babluboy.nut
 This will add the icon of Nutty to your desktop icon's tray (or) icon's menu.
 
 You can also check if Nutty is properly installed or not in your system by using the below command.
-```bash
+```
+flatpak list (or)
 flatpak list --app
 ```
 Upon executing this command you should be able to see `Nutty` under the "Name"" sections and `com.github.babluboy.nutty` under "Application-ID" section.
@@ -58,13 +60,3 @@ Cheers👍
 
 #### Author
 *Kishor* [Github](https://github.com/root-reborn)
-
-
-
-
-
-
-
-
-
-

--- a/com.github.babluboy.nutty.json
+++ b/com.github.babluboy.nutty.json
@@ -15,25 +15,6 @@
     "--talk-name=org.freedesktop.Notifications"
   ],
   "modules": [
-{
-  "name": "canberra-gtk-module",
-  "buildsystem": "autotools",
-  "config-opts": [
-    "--prefix=/app"
-  ],
-  "build-commands": [
-    "./configure --prefix=/app",
-    "make",
-    "make install"
-  ],
-  "sources": [
-    {
-      "type": "archive",
-      "url": "https://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
-      "sha256": "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
-    }
-  ]
-},
     {
       "name": "granite",
       "buildsystem": "meson",
@@ -158,9 +139,9 @@
       ],
       "sources": [
         {
-          "type": "archive",
-          "url": "https://github.com/HewlettPackard/wireless-tools/archive/refs/tags/v29.tar.gz",
-          "sha256": "69c5face9ac9d3273042436408a9a057d3416a814253dedeaaef210fcbc42d40"
+          "type": "git",
+          "url": "https://github.com/HewlettPackard/wireless-tools.git",
+         "tag": "v29"
         }
       ]
     },
@@ -198,6 +179,21 @@
           "type": "archive",
           "url": "https://github.com/pciutils/pciutils/archive/v3.8.0.tar.gz",
           "sha256": "71189a1297e39d2638dd5691a102d2aecd7db8083e6de376c115e8996eeda027"
+        }
+      ]
+    },
+      {
+      "name": "lshw",
+      "buildsystem": "simple",
+      "build-commands": [
+       "make",
+       "make install PREFIX=/app"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.ezix.org/software/files/lshw-B.02.19.2.tar.gz",
+          "sha256": "9bb347ac87142339a366a1759ac845e3dbb337ec000aa1b99b50ac6758a80f80"
         }
       ]
     },


### PR DESCRIPTION
Added lshw module to flatpak manifest since it is not present in the gnome runtime but is used by Nutty as specified in nutty_cli_script.sh shell script.Also removed the canberra-gtk-module from flatpak manifest as it is not required.Made few typos changes in the Build Instructions of flatpak